### PR TITLE
Allow retrieving kubeconfigs without exec config, too.

### DIFF
--- a/cmd/admin/v1/cluster.go
+++ b/cmd/admin/v1/cluster.go
@@ -216,7 +216,7 @@ func (c *cluster) kubeconfig(args []string) error {
 		return fmt.Errorf("unable to write merged kubeconfig: %w", err)
 	}
 
-	_, _ = fmt.Fprintf(c.c.Out, "%s merged context %q into %s\n", color.GreenString("✔"), kubeconfig.ContextName, kubeconfig.Path)
+	_, _ = fmt.Fprintf(c.c.Out, "%s wrote context %q into %s\n", color.GreenString("✔"), kubeconfig.ContextName, kubeconfig.Path)
 
 	return nil
 }

--- a/cmd/admin/v1/cluster.go
+++ b/cmd/admin/v1/cluster.go
@@ -72,8 +72,14 @@ func newClusterCmd(c *config.Config) *cobra.Command {
 	}
 
 	kubeconfigCmd.Flags().DurationP("expiration", "", 8*time.Hour, "kubeconfig will expire after given time")
-	kubeconfigCmd.Flags().Bool("merge", true, "merges the kubeconfig into default kubeconfig instead of printing it to the console")
+	kubeconfigCmd.Flags().Bool("merge", true, "merges the kubeconfig into the current kubeconfig")
+	kubeconfigCmd.Flags().Bool("print-only", false, "only prints the kubeconfig to the console instead of writing it")
+	kubeconfigCmd.Flags().String("auth-type", string(kubernetes.AuthTypeExec), `the way how the resulting kubeconfig authenticates at the api server. can be "exec" or "certs".
+	  "exec" injects an exec config into the kubeconfig, which uses this CLI to automatically renew certificates when they expire.
+	  "certs" simply adds the client certificates to the kubeconfig, there is no automatic renewal once the certificates have expired, the CLI is not called automatically.`)
 	kubeconfigCmd.Flags().String("kubeconfig", "", "specify an explicit path for the merged kubeconfig to be written, defaults to default kubeconfig paths if not provided")
+
+	genericcli.Must(kubeconfigCmd.RegisterFlagCompletionFunc("auth-type", c.Completion.ClusterKubeconfigAuthType))
 
 	// metal admin cluster machine list
 
@@ -195,26 +201,22 @@ func (c *cluster) kubeconfig(args []string) error {
 		return fmt.Errorf("failed to get cluster credentials: %w", err)
 	}
 
-	if !viper.GetBool("merge") {
-		_, _ = fmt.Fprintln(c.c.Out, resp.Msg.Kubeconfig)
-		return nil
-	}
-
-	var (
-		kubeconfigPath = viper.GetString("kubeconfig")
-	)
-
-	merged, err := kubernetes.MergeKubeconfig(c.c.Fs, []byte(resp.Msg.Kubeconfig), pointer.PointerOrNil(kubeconfigPath), nil, c.c.GetProject(), id) // FIXME: reverse lookup project name
+	kubeconfig, err := kubernetes.NewKubeconfigFromRaw(c.c.Fs, []byte(resp.Msg.Kubeconfig), nil, c.c.GetProject(), id) // FIXME: reverse lookup project name
 	if err != nil {
 		return err
 	}
 
-	err = afero.WriteFile(c.c.Fs, merged.Path, merged.Raw, 0600)
+	if viper.GetBool("print-only") {
+		_, _ = fmt.Fprintln(c.c.Out, string(kubeconfig.Raw))
+		return nil
+	}
+
+	err = afero.WriteFile(c.c.Fs, kubeconfig.Path, kubeconfig.Raw, 0600)
 	if err != nil {
 		return fmt.Errorf("unable to write merged kubeconfig: %w", err)
 	}
 
-	_, _ = fmt.Fprintf(c.c.Out, "%s merged context %q into %s\n", color.GreenString("✔"), merged.ContextName, merged.Path)
+	_, _ = fmt.Fprintf(c.c.Out, "%s merged context %q into %s\n", color.GreenString("✔"), kubeconfig.ContextName, kubeconfig.Path)
 
 	return nil
 }

--- a/cmd/admin/v1/cluster.go
+++ b/cmd/admin/v1/cluster.go
@@ -201,7 +201,7 @@ func (c *cluster) kubeconfig(args []string) error {
 		return fmt.Errorf("failed to get cluster credentials: %w", err)
 	}
 
-	kubeconfig, err := kubernetes.NewKubeconfigFromRaw(c.c.Fs, []byte(resp.Msg.Kubeconfig), nil, c.c.GetProject(), id) // FIXME: reverse lookup project name
+	kubeconfig, err := kubernetes.NewKubeconfigFromRaw(c.c.Fs, c.c.In, c.c.Out, []byte(resp.Msg.Kubeconfig), nil, c.c.GetProject(), id) // FIXME: reverse lookup project name
 	if err != nil {
 		return err
 	}

--- a/cmd/api/v1/cluster.go
+++ b/cmd/api/v1/cluster.go
@@ -592,7 +592,7 @@ func (c *cluster) kubeconfig(args []string) error {
 		return fmt.Errorf("unable to write merged kubeconfig: %w", err)
 	}
 
-	_, _ = fmt.Fprintf(c.c.Out, "%s merged context %q into %s\n", color.GreenString("✔"), kubeconfig.ContextName, kubeconfig.Path)
+	_, _ = fmt.Fprintf(c.c.Out, "%s wrote context %q into %s\n", color.GreenString("✔"), kubeconfig.ContextName, kubeconfig.Path)
 
 	return nil
 }

--- a/cmd/api/v1/cluster.go
+++ b/cmd/api/v1/cluster.go
@@ -116,10 +116,15 @@ func newClusterCmd(c *config.Config) *cobra.Command {
 
 	kubeconfigCmd.Flags().StringP("project", "p", "", "the project in which the cluster resides for which to get the kubeconfig for")
 	kubeconfigCmd.Flags().DurationP("expiration", "", 8*time.Hour, "kubeconfig will expire after given time")
-	kubeconfigCmd.Flags().Bool("merge", true, "merges the kubeconfig into default kubeconfig instead of printing it to the console")
+	kubeconfigCmd.Flags().Bool("merge", true, "merges the kubeconfig into the current kubeconfig")
+	kubeconfigCmd.Flags().Bool("print-only", false, "only prints the kubeconfig to the console instead of writing it")
+	kubeconfigCmd.Flags().String("auth-type", string(kubernetes.AuthTypeExec), `the way how the resulting kubeconfig authenticates at the api server. can be "exec" or "certs".
+	  "exec" injects an exec config into the kubeconfig, which uses this CLI to automatically renew certificates when they expire.
+	  "certs" simply adds the client certificates to the kubeconfig, there is no automatic renewal once the certificates have expired, the CLI is not called automatically.`)
 	kubeconfigCmd.Flags().String("kubeconfig", "", "specify an explicit path for the merged kubeconfig to be written, defaults to default kubeconfig paths if not provided")
 
 	genericcli.Must(kubeconfigCmd.RegisterFlagCompletionFunc("project", c.Completion.ProjectListCompletion))
+	genericcli.Must(kubeconfigCmd.RegisterFlagCompletionFunc("auth-type", c.Completion.ClusterKubeconfigAuthType))
 
 	execConfigCmd := &cobra.Command{
 		Use:   "exec-config",
@@ -563,32 +568,31 @@ func (c *cluster) kubeconfig(args []string) error {
 		return fmt.Errorf("failed to get cluster credentials: %w", err)
 	}
 
-	if !viper.GetBool("merge") {
-		_, _ = fmt.Fprintln(c.c.Out, resp.Msg.Kubeconfig)
-		return nil
-	}
-
 	projectResp, err := c.c.Client.Apiv1().Project().Get(ctx, connect.NewRequest(&apiv1.ProjectServiceGetRequest{Project: c.c.GetProject()}))
 	if err != nil {
 		return err
 	}
 
 	var (
-		kubeconfigPath = viper.GetString("kubeconfig")
-		projectName    = helpers.TrimProvider(projectResp.Msg.Project.Name)
+		projectName = helpers.TrimProvider(projectResp.Msg.Project.Name)
 	)
 
-	merged, err := kubernetes.MergeKubeconfig(c.c.Fs, []byte(resp.Msg.Kubeconfig), pointer.PointerOrNil(kubeconfigPath), &projectName, projectResp.Msg.Project.Uuid, id)
+	kubeconfig, err := kubernetes.NewKubeconfigFromRaw(c.c.Fs, []byte(resp.Msg.Kubeconfig), &projectName, projectResp.Msg.Project.Uuid, id)
 	if err != nil {
 		return err
 	}
 
-	err = afero.WriteFile(c.c.Fs, merged.Path, merged.Raw, 0600)
+	if viper.GetBool("print-only") {
+		_, _ = fmt.Fprintln(c.c.Out, string(kubeconfig.Raw))
+		return nil
+	}
+
+	err = afero.WriteFile(c.c.Fs, kubeconfig.Path, kubeconfig.Raw, 0600)
 	if err != nil {
 		return fmt.Errorf("unable to write merged kubeconfig: %w", err)
 	}
 
-	_, _ = fmt.Fprintf(c.c.Out, "%s merged context %q into %s\n", color.GreenString("✔"), merged.ContextName, merged.Path)
+	_, _ = fmt.Fprintf(c.c.Out, "%s merged context %q into %s\n", color.GreenString("✔"), kubeconfig.ContextName, kubeconfig.Path)
 
 	return nil
 }

--- a/cmd/api/v1/cluster.go
+++ b/cmd/api/v1/cluster.go
@@ -577,7 +577,7 @@ func (c *cluster) kubeconfig(args []string) error {
 		projectName = helpers.TrimProvider(projectResp.Msg.Project.Name)
 	)
 
-	kubeconfig, err := kubernetes.NewKubeconfigFromRaw(c.c.Fs, []byte(resp.Msg.Kubeconfig), &projectName, projectResp.Msg.Project.Uuid, id)
+	kubeconfig, err := kubernetes.NewKubeconfigFromRaw(c.c.Fs, c.c.In, c.c.Out, []byte(resp.Msg.Kubeconfig), &projectName, projectResp.Msg.Project.Uuid, id)
 	if err != nil {
 		return err
 	}

--- a/cmd/completion/cluster.go
+++ b/cmd/completion/cluster.go
@@ -4,6 +4,7 @@ import (
 	"connectrpc.com/connect"
 	adminv1 "github.com/metal-stack-cloud/api/go/admin/v1"
 	apiv1 "github.com/metal-stack-cloud/api/go/api/v1"
+	"github.com/metal-stack-cloud/cli/cmd/kubernetes"
 	"github.com/metal-stack/metal-lib/pkg/genericcli"
 	"github.com/spf13/cobra"
 )
@@ -107,8 +108,6 @@ func (c *Completion) AdminClusterFirewallListCompletion(cmd *cobra.Command, args
 
 	var names []string
 	for _, machine := range resp.Msg.Machines {
-		machine := machine
-
 		if machine.Role != "firewall" {
 			continue
 		}
@@ -117,4 +116,8 @@ func (c *Completion) AdminClusterFirewallListCompletion(cmd *cobra.Command, args
 	}
 
 	return names, cobra.ShellCompDirectiveNoFileComp
+}
+
+func (c *Completion) ClusterKubeconfigAuthType(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return []string{string(kubernetes.AuthTypeExec), string(kubernetes.AuthTypeClientCerts)}, cobra.ShellCompDirectiveNoFileComp
 }

--- a/cmd/kubernetes/kubeconfig.go
+++ b/cmd/kubernetes/kubeconfig.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/spf13/afero"
+	"github.com/spf13/viper"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -14,16 +15,23 @@ import (
 	configv1 "k8s.io/client-go/tools/clientcmd/api/v1"
 )
 
-type MergedKubeconfig struct {
+type authType string
+
+const (
+	AuthTypeClientCerts authType = "certs"
+	AuthTypeExec        authType = "exec"
+)
+
+type Kubeconfig struct {
 	Raw         []byte
 	Path        string
 	ContextName string
 }
 
-func MergeKubeconfig(fs afero.Fs, raw []byte, kubeconfigPath, projectName *string, projectid, clusterid string) (*MergedKubeconfig, error) {
+func NewKubeconfigFromRaw(fs afero.Fs, raw []byte, projectName *string, projectid, clusterid string) (*Kubeconfig, error) {
 	path := os.Getenv(clientcmd.RecommendedConfigPathEnvVar)
-	if kubeconfigPath != nil {
-		path = *kubeconfigPath
+	if userPath := viper.GetString("kubeconfig"); userPath != "" {
+		path = userPath
 	}
 	if path == "" {
 		path = clientcmd.RecommendedHomeFile
@@ -40,13 +48,8 @@ func MergeKubeconfig(fs afero.Fs, raw []byte, kubeconfigPath, projectName *strin
 		}
 	}
 
-	currentConfig, err := clientcmd.LoadFromFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("error loading kubeconfig: %w", err)
-	}
-
 	kubeconfig := &configv1.Config{}
-	err = runtime.DecodeInto(configlatest.Codec, raw, kubeconfig)
+	err := runtime.DecodeInto(configlatest.Codec, raw, kubeconfig)
 	if err != nil {
 		return nil, fmt.Errorf("unable to decode kubeconfig: %w", err)
 	}
@@ -58,8 +61,6 @@ func MergeKubeconfig(fs afero.Fs, raw []byte, kubeconfigPath, projectName *strin
 	)
 
 	for _, cl := range kubeconfig.Clusters {
-		cl := cl
-
 		prefix, _, found := strings.Cut(cl.Name, "-external")
 		if !found {
 			continue
@@ -73,8 +74,6 @@ func MergeKubeconfig(fs afero.Fs, raw []byte, kubeconfigPath, projectName *strin
 	}
 
 	for _, a := range kubeconfig.AuthInfos {
-		a := a
-
 		if !strings.HasSuffix(a.Name, clusterName+"-external") {
 			continue
 		}
@@ -91,30 +90,67 @@ func MergeKubeconfig(fs afero.Fs, raw []byte, kubeconfigPath, projectName *strin
 		contextName = fmt.Sprintf("%s-%s@metalstack.cloud", clusterName, *projectName)
 	}
 
+	currentConfig := &api.Config{
+		Clusters:  map[string]*api.Cluster{},
+		Contexts:  map[string]*api.Context{},
+		AuthInfos: map[string]*api.AuthInfo{},
+	}
+	if viper.GetBool("merge") {
+		var err error
+		currentConfig, err = clientcmd.LoadFromFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("error loading kubeconfig: %w", err)
+		}
+	}
+
 	currentConfig.Contexts[contextName] = &api.Context{
 		Cluster:  contextName,
 		AuthInfo: contextName,
 	}
+
 	currentConfig.Clusters[contextName] = &api.Cluster{
 		Server:                   cluster.Cluster.Server,
 		CertificateAuthorityData: cluster.Cluster.CertificateAuthorityData,
 	}
 
-	metalcli, err := os.Executable()
-	if err != nil {
-		return nil, fmt.Errorf("unable to get executable path: %w", err)
-	}
-	currentConfig.AuthInfos[contextName] = &api.AuthInfo{
-		Exec: &api.ExecConfig{
-			Command:         metalcli,
-			Args:            []string{"cluster", "exec-config", "-p", projectid, clusterid},
-			APIVersion:      "client.authentication.k8s.io/v1", // since k8s 1.22, if earlier versions are used, the API version is client.authentication.k8s.io/v1beta1
-			InteractiveMode: api.IfAvailableExecInteractiveMode,
-		},
-	}
-
 	if currentConfig.CurrentContext == "" {
 		currentConfig.CurrentContext = contextName
+	}
+
+	auth := AuthTypeExec
+	if viper.GetString("auth-type") != "" {
+		auth = authType(viper.GetString("auth-type"))
+	}
+
+	switch auth {
+	case AuthTypeExec:
+		metalcli, err := os.Executable()
+		if err != nil {
+			return nil, fmt.Errorf("unable to get executable path: %w", err)
+		}
+
+		currentConfig.AuthInfos[contextName] = &api.AuthInfo{
+			Exec: &api.ExecConfig{
+				Command:         metalcli,
+				Args:            []string{"cluster", "exec-config", "-p", projectid, clusterid},
+				APIVersion:      "client.authentication.k8s.io/v1", // since k8s 1.22, if earlier versions are used, the API version is client.authentication.k8s.io/v1beta1
+				InteractiveMode: api.IfAvailableExecInteractiveMode,
+			},
+		}
+
+		ec, err := NewUserExecCache(fs)
+		if err != nil {
+			return nil, err
+		}
+		// remove cached credentials so a new one will be created
+		_ = ec.Clean(clusterid)
+	case AuthTypeClientCerts:
+		currentConfig.AuthInfos[contextName] = &api.AuthInfo{
+			ClientCertificateData: authInfo.ClientCertificateData,
+			ClientKeyData:         authInfo.ClientKeyData,
+		}
+	default:
+		return nil, fmt.Errorf("unsupported auth type for kubeconfig: %s", auth)
 	}
 
 	merged, err := runtime.Encode(configlatest.Codec, currentConfig)
@@ -122,14 +158,7 @@ func MergeKubeconfig(fs afero.Fs, raw []byte, kubeconfigPath, projectName *strin
 		return nil, fmt.Errorf("unable to encode kubeconfig: %w", err)
 	}
 
-	ec, err := NewUserExecCache(fs)
-	if err != nil {
-		return nil, err
-	}
-	// remove cached credentials so a new one will be created
-	_ = ec.Clean(clusterid)
-
-	return &MergedKubeconfig{
+	return &Kubeconfig{
 		Raw:         merged,
 		ContextName: contextName,
 		Path:        path,

--- a/cmd/kubernetes/kubeconfig.go
+++ b/cmd/kubernetes/kubeconfig.go
@@ -147,7 +147,7 @@ func NewKubeconfigFromRaw(fs afero.Fs, in io.Reader, out io.Writer, raw []byte, 
 			Exec: &api.ExecConfig{
 				Command:         metalcli,
 				Args:            []string{"cluster", "exec-config", "-p", projectid, clusterid},
-				APIVersion:      "client.authentication.k8s.io/v1", // since k8s 1.22, if earlier versions are used, the API version is client.authentication.k8s.io/v1beta1
+				APIVersion:      "client.authentication.k8s.io/v1",
 				InteractiveMode: api.IfAvailableExecInteractiveMode,
 			},
 		}

--- a/cmd/kubernetes/kubeconfig.go
+++ b/cmd/kubernetes/kubeconfig.go
@@ -2,9 +2,12 @@ package kubernetes
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
+	"github.com/fatih/color"
+	"github.com/metal-stack/metal-lib/pkg/genericcli"
 	"github.com/spf13/afero"
 	"github.com/spf13/viper"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -28,7 +31,7 @@ type Kubeconfig struct {
 	ContextName string
 }
 
-func NewKubeconfigFromRaw(fs afero.Fs, raw []byte, projectName *string, projectid, clusterid string) (*Kubeconfig, error) {
+func NewKubeconfigFromRaw(fs afero.Fs, in io.Reader, out io.Writer, raw []byte, projectName *string, projectid, clusterid string) (*Kubeconfig, error) {
 	path := os.Getenv(clientcmd.RecommendedConfigPathEnvVar)
 	if userPath := viper.GetString("kubeconfig"); userPath != "" {
 		path = userPath
@@ -41,15 +44,13 @@ func NewKubeconfigFromRaw(fs afero.Fs, raw []byte, projectName *string, projecti
 		return nil, fmt.Errorf("it is currently not supported to merge when multiple kubeconfigs are provided")
 	}
 
-	if _, err := fs.Stat(path); os.IsNotExist(err) {
-		err := afero.WriteFile(fs, path, nil, 0600)
-		if err != nil {
-			return nil, fmt.Errorf("error to write to: %w", err)
-		}
+	exists, err := afero.Exists(fs, path)
+	if err != nil {
+		return nil, fmt.Errorf("unable to determine if file exists: %w", err)
 	}
 
 	kubeconfig := &configv1.Config{}
-	err := runtime.DecodeInto(configlatest.Codec, raw, kubeconfig)
+	err = runtime.DecodeInto(configlatest.Codec, raw, kubeconfig)
 	if err != nil {
 		return nil, fmt.Errorf("unable to decode kubeconfig: %w", err)
 	}
@@ -95,11 +96,24 @@ func NewKubeconfigFromRaw(fs afero.Fs, raw []byte, projectName *string, projecti
 		Contexts:  map[string]*api.Context{},
 		AuthInfos: map[string]*api.AuthInfo{},
 	}
+
 	if viper.GetBool("merge") {
 		var err error
 		currentConfig, err = clientcmd.LoadFromFile(path)
 		if err != nil {
 			return nil, fmt.Errorf("error loading kubeconfig: %w", err)
+		}
+	} else {
+		if exists {
+			err = genericcli.PromptCustom(&genericcli.PromptConfig{
+				Message:     fmt.Sprintf(color.YellowString("There is already a file at %s. In combination with --merge=false this file will be overwritten. Are you sure you want to continue?"), path),
+				ShowAnswers: true,
+				In:          in,
+				Out:         out,
+			})
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/docs/metal_cluster_kubeconfig.md
+++ b/docs/metal_cluster_kubeconfig.md
@@ -9,10 +9,14 @@ metal cluster kubeconfig [flags]
 ### Options
 
 ```
+      --auth-type string      the way how the resulting kubeconfig authenticates at the api server. can be "exec" or "certs".
+                              	  "exec" injects an exec config into the kubeconfig, which uses this CLI to automatically renew certificates when they expire.
+                              	  "certs" simply adds the client certificates to the kubeconfig, there is no automatic renewal once the certificates have expired, the CLI is not called automatically. (default "exec")
       --expiration duration   kubeconfig will expire after given time (default 8h0m0s)
   -h, --help                  help for kubeconfig
       --kubeconfig string     specify an explicit path for the merged kubeconfig to be written, defaults to default kubeconfig paths if not provided
-      --merge                 merges the kubeconfig into default kubeconfig instead of printing it to the console (default true)
+      --merge                 merges the kubeconfig into the current kubeconfig (default true)
+      --print-only            only prints the kubeconfig to the console instead of writing it
   -p, --project string        the project in which the cluster resides for which to get the kubeconfig for
 ```
 


### PR DESCRIPTION
Follow-up of https://github.com/metal-stack-cloud/cli/pull/78.

We would like to use the kubeconfig in contexts where we do not necessarily have the metal CLI in place. For this use-case it would be nice to just write the client certificates into the kubeconfig and not using exec credentials.

In addition to this, I tried to resolve another inconsistency, which users encounter when using `--merge=false`. They currently retrieve a kubeconfig directly from Gardener containing two kubeconfigs, which makes no sense for them. Also when using `--merge=false`, we only printed this kubeconfig, which is not really intuitive. Merging and printing are two different things.

With this PR, I introduced the following changes:

- The returned kubeconfig is now always cleaned (free of Gardener specifics)
- New flag `--print-only` 
  - The flag causes not write the kubeconfig to the filesystem (as said `--merge` does not really have anything to do with printing)
- New flag `--auth-type=exec` or `--auth-type=certs`
  - This allows people to choose if the exec credential should be injected or we just pass on the client certificates directly